### PR TITLE
SFM-401 Do not allow commas in the content headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ Activate the plugin and go to Settings -> Post Payments. Select the post types t
 * Bug - Fixed issue where commas in post titles would create additional columns in the report output.
 
 1.2 - Add cost to guest authors and relate it to posts when author is selected.
+
+1.3 - Bug fix for ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION when trying to download the report in Chrome

--- a/post-payments.php
+++ b/post-payments.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Post Payments
  * Description: Tracks story cost and payment due totals.
- * Version: 1.2
+ * Version: 1.3
  * Author: Matt Johnson, Alley Interactive
  *
  */
@@ -248,7 +248,7 @@ class Post_Payments {
 			}
 			// setting headers
 			header( 'Content-Type: text/csv; charset=utf-8' );
-			header( 'Content-Disposition: attachment; filename=' . sanitize_text_field( $_GET['from_date'] ) . '-to-' . sanitize_text_field( $_GET['to_date'] ) . '-author-data.csv' );
+			header( 'Content-Disposition: attachment; filename=' . sanitize_title( $_GET['from_date'] ) . '-to-' . sanitize_title( $_GET['to_date'] ) . '-author-data.csv' );
 			// getting authors for report
 			$authors = $this->get_report_data( sanitize_text_field( $_GET['from_date'] ), sanitize_text_field( $_GET['to_date'] ) );
 			// start creating the csv string


### PR DESCRIPTION
Allowing commas (the date formatted) will cause Chrome to throw a `ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION` error. This sanitizes the filename.